### PR TITLE
Fix autoloading, add phpunit.xml.dist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,7 @@
         "mockery/mockery": "~0.9"
     },
     "autoload": {
-        "psr-0": {
-            "TinyHttp": "src"
-        }
+        "classmap": ["src/TinyHttp.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "mockery/mockery": "~0.9"
     },
     "autoload": {
-        "psr-4": {
-            "eddiezane\\TinyHttp\\": "src"
+        "psr-0": {
+            "TinyHttp": "src"
         }
     },
     "autoload-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="TinyHttp Test Suite">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
The test now works!

PSR-4 is class-per-file and assumes namespaces. Since we're 5.2 compatible on this (so Twilio can use it), no namespaces allowed. So PSR-0 is what we want, similar to how Twilio's own composer.json file is set up.
